### PR TITLE
feat(store): expose reactive canUndo/canRedo getters on useTravelStore controls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,19 @@ type StoreControls<
   ? RebasableTravelsControls<S, F, P>
   : RebasableManualTravelsControls<S, F, P>;
 
+/** {@link StoreControls} plus reactive `canUndo` / `canRedo` flags. */
+type StoreControlsWithFlags<
+  S,
+  F extends boolean,
+  A extends boolean,
+  P extends PatchesOption = {},
+> = StoreControls<S, F, A, P> & {
+  /** Whether undo is possible. Reactive getter — safe to read during render. */
+  readonly canUndo: boolean;
+  /** Whether redo is possible. Reactive getter — safe to read during render. */
+  readonly canRedo: boolean;
+};
+
 /**
  * Creates a component-scoped {@link Travels} instance with undo/redo support and returns its reactive API.
  *
@@ -237,7 +250,11 @@ export function useTravelStore<
   P extends PatchesOption = {},
 >(
   travels: Travels<S, F, A, P>
-): [Value<S, F>, (updater: Updater<S>) => void, StoreControls<S, F, A, P>] {
+): [
+  Value<S, F>,
+  (updater: Updater<S>) => void,
+  StoreControlsWithFlags<S, F, A, P>,
+] {
   const isMutable = Boolean((travels as any)?.mutable);
 
   if (isMutable) {
@@ -254,9 +271,16 @@ export function useTravelStore<
     (updater: Updater<S>) => travels.setState(updater),
     [travels]
   );
-  const controls = useMemo<StoreControls<S, F, A, P>>(
-    () => travels.getControls(),
-    [travels]
-  );
+  const controls = useMemo<StoreControlsWithFlags<S, F, A, P>>(() => {
+    const base = travels.getControls();
+    // Expose canUndo/canRedo as getters mirroring canBack()/canForward(). Property
+    // reads (unlike method calls) are not memoised by the React Compiler on the stable
+    // `controls` reference, so these stay reactive when read during render — the same
+    // way `controls.position` already does — while `controls` itself stays stable.
+    return Object.create(base, {
+      canUndo: { get: () => base.canBack(), enumerable: true },
+      canRedo: { get: () => base.canForward(), enumerable: true },
+    }) as StoreControlsWithFlags<S, F, A, P>;
+  }, [travels]);
   return [state as Value<S, F>, setState, controls];
 }

--- a/test/use-travel-store.test.ts
+++ b/test/use-travel-store.test.ts
@@ -46,6 +46,35 @@ describe('useTravelStore', () => {
     expect(controls.getHistory()).toEqual(travels.getHistory());
   });
 
+  it('exposes reactive canUndo/canRedo getters while keeping controls stable', () => {
+    const travels = new Travels({ count: 0 });
+
+    const { result } = renderHook(() => useTravelStore(travels));
+
+    const [, setState, controlsBefore] = result.current;
+    expect(controlsBefore.canUndo).toBe(false);
+    expect(controlsBefore.canRedo).toBe(false);
+
+    act(() =>
+      setState((draft) => {
+        draft.count = 1;
+      })
+    );
+
+    const [, , controlsAfter] = result.current;
+
+    expect(controlsAfter).toBe(controlsBefore);
+    expect(controlsAfter.canUndo).toBe(true);
+    expect(controlsAfter.canRedo).toBe(false);
+    expect(controlsAfter.canBack()).toBe(true);
+
+    act(() => controlsAfter.back());
+    const [, , controlsAfterUndo] = result.current;
+
+    expect(controlsAfterUndo.canUndo).toBe(false);
+    expect(controlsAfterUndo.canRedo).toBe(true);
+  });
+
   it('exposes manual archive controls when autoArchive is disabled', () => {
     const travels = new Travels(
       { todos: [] as string[] },


### PR DESCRIPTION
## Summary

Reading `controls.canBack()` / `canForward()` during render — the documented
`disabled={!controls.canBack()}` pattern — freezes under the React Compiler: it
memoises the method call on the stable `controls` reference, so the value never updates.

This adds `canUndo` / `canRedo` as **getters** on the `useTravelStore` controls.
Property reads aren't memoised that way (the existing `position` getter works for the
same reason), so they stay reactive in render; `controls` keeps a stable identity.
`canBack()` / `canForward()` remain for event handlers — the getters are the
render-time form. Relates to #12.

## Why getters

Under the React Compiler, `obj.method()` results are memoised on the object reference;
`obj.prop` reads are not. That's why `position` worked in render and `canBack()` didn't.

## Usage

```ts
const [state, setState, controls] = useTravelStore(travels);

// render — getter (reactive under the compiler)
<button disabled={!controls.canUndo} onClick={() => controls.back()}>Undo</button>

// event handler — method is fine here
onClick={() => controls.canBack() && controls.back()}
```

## Verification

- New unit test; all existing tests and `tsc` pass.
- Manually verified under Vite + React Compiler: `canUndo` updates in render while
  `canBack()` stays frozen.

## Tradeoff / open question

React Compiler adoption is still early, so this likely affects few users today — but it
will grow, and under it the documented `disabled={!controls.canBack()}` pattern breaks
silently. The render-time check also shifts from `canBack()` to the getters (a second
form). Rather than decide that silently, two directions:

- **Add the getters (this PR)** — additive and low-risk; opt-in for compiler users,
  nothing changes for everyone else.
- **Docs-only for now** — document the caveat (read via `useSyncExternalStore`) and
  revisit as adoption grows.
